### PR TITLE
Path subfolders for experiment and data content

### DIFF
--- a/R/trial_survey_text.R
+++ b/R/trial_survey_text.R
@@ -166,6 +166,7 @@ trial_survey_text <- function(
 #' @param placeholder A string specifying the placeholder text
 #' @param rows Number of rows spanned by the text box
 #' @param columns Number of columns spanned by the text box
+#' @param required Is a response to the question required?
 #' @param name A convenient label for the question
 #'
 #' @return A question object to be passed to \code{\link{trial_survey_text}()}.
@@ -180,6 +181,9 @@ trial_survey_text <- function(
 #' (e.g., \code{placeholder = "Type your answer here"})
 #' it is displayed in faded text within the box, and will disappear as soon as
 #' the participant begins typing the response.
+#'
+#' If \code{required = TRUE} the participant will not
+#' be allowed to continue to the next trial unless an answer is provided.
 #'
 #' The \code{name} argument should be a string that provides a convenient
 #' label for the question. If left unspecified, jsPsych defaults to labelling
@@ -198,6 +202,7 @@ question_text <- function(
   placeholder = "",
   rows = 1,
   columns = 40,
+  required = FALSE,
   name = NULL
 ) {
   q <- drop_nulls(
@@ -206,6 +211,7 @@ question_text <- function(
       placeholder = placeholder,
       rows = rows,
       columns = columns,
+      required = required,
       name = name
     )
   )

--- a/man/build_experiment.Rd
+++ b/man/build_experiment.Rd
@@ -4,12 +4,24 @@
 \alias{build_experiment}
 \title{Build the experiment files}
 \usage{
-build_experiment(timeline, path, resources = NULL, columns = NULL, ...)
+build_experiment(
+  timeline,
+  path,
+  experiment_folder = "experiment",
+  data_folder = "data",
+  resources = NULL,
+  columns = NULL,
+  ...
+)
 }
 \arguments{
 \item{timeline}{A timeline object}
 
-\item{path}{A string specifying a folder in which to build the experiment}
+\item{path}{A string specifying the path in which to build the experiment}
+
+\item{experiment_folder}{A string specifying the experiment subfolder}
+
+\item{data_folder}{A string specifying the data subfolder}
 
 \item{resources}{A tibble specifying how to construct resource files, or NULL}
 
@@ -37,13 +49,15 @@ function for a more detailed description of what this tibble should contain.
 
 When called, the \code{build_experiment()} function writes all the experiment files,
 compiled to javascript and HTML. The file structure it creates is as follows. Within
-the \code{path} folder are two subfolders, named "data" and "experiment". The "data"
-folder is empty, but intended to serve as a location to which data files can be
-written. The "experiment" folder contains the "index.html" file, which is the primary
-source file for the experiment page, and an "experiment.js" file that specifies the
-jsPsych timeline and calls the jsPsych.init() javascript function that starts the
-experiment running. It also contains a "resource" folder with other necessary files
-(see \code{\link{build_resources}()} for detail).
+the \code{path} folder are two subfolders, \code{data_folder} and
+\code{experiment_folder} (named "data" and "experiment" by default). The
+\code{data_folder} folder is empty, but intended to serve as a location to which
+data files can be written. The \code{experiment_folder} folder contains the
+"index.html" file, which is the primary source file for the experiment page, and an
+"experiment.js" file that specifies the jsPsych timeline and calls the
+jsPsych.init() javascript function that starts the experiment running. It also
+contains a "resource" folder with other necessary files (see
+\code{\link{build_resources}()} for detail).
 
 Because \code{build_experiment()} creates the call to jsPsych.init(), it can also
 be used to specify any parameters that the user may wish to pass to that function

--- a/man/question_text.Rd
+++ b/man/question_text.Rd
@@ -4,7 +4,14 @@
 \alias{question_text}
 \title{Create a free text response question}
 \usage{
-question_text(prompt, placeholder = "", rows = 1, columns = 40, name = NULL)
+question_text(
+  prompt,
+  placeholder = "",
+  rows = 1,
+  columns = 40,
+  required = FALSE,
+  name = NULL
+)
 }
 \arguments{
 \item{prompt}{The prompt for the question}
@@ -14,6 +21,8 @@ question_text(prompt, placeholder = "", rows = 1, columns = 40, name = NULL)
 \item{rows}{Number of rows spanned by the text box}
 
 \item{columns}{Number of columns spanned by the text box}
+
+\item{required}{Is a response to the question required?}
 
 \item{name}{A convenient label for the question}
 }
@@ -34,6 +43,9 @@ a \code{placeholder} string is specified
 (e.g., \code{placeholder = "Type your answer here"})
 it is displayed in faded text within the box, and will disappear as soon as
 the participant begins typing the response.
+
+If \code{required = TRUE} the participant will not
+be allowed to continue to the next trial unless an answer is provided.
 
 The \code{name} argument should be a string that provides a convenient
 label for the question. If left unspecified, jsPsych defaults to labelling

--- a/man/run_googlecloud.Rd
+++ b/man/run_googlecloud.Rd
@@ -2,28 +2,29 @@
 % Please edit documentation in R/build_api.R
 \name{run_googlecloud}
 \alias{run_googlecloud}
-\title{Deploy a jspsych experiment on google app engie}
+\title{Deploy a jspsych experiment on google app engine}
 \usage{
-run_googlecloud(path, project_id)
+run_googlecloud(path, experiment_folder = "experiment", project_id)
 }
 \arguments{
-\item{path}{path to the experiment folder}
+\item{path}{Path where the experiment is deployed}
+
+\item{experiment_folder}{Experiment subfolder}
 
 \item{project_id}{the google app engine project id}
 }
 \description{
-Deploy a jspsych experiment on google app engie
+Deploy a jspsych experiment on google app engine
 }
 \details{
 The purpose of the \code{run_googlecloud()} function is to make it
 somewhat easier to deploy a jsPsych experiment to Google App Engine, so that
 the experiment can run in the cloud rather than on the local machine.
-The \code{path} argument
-specifies the location of the experiment to be deployed, and should be the same
-as the value of \code{path} that was used when calling
-\code{\link{build_experiment}()}) to build the experiment originally. The
-\code{project_id} is the name of the Google App Engine project that will host
-the experiment.
+The \code{path} and \code{experiment_folder} arguments
+specify where the experiment should be deployed, and should be the same
+that was used when calling \code{\link{build_experiment}()}) to build the
+experiment originally. The \code{project_id} is the name of the Google App
+Engine project that will host the experiment.
 
 At present, the functionality of \code{run_googlecloud()} is quite limited. All
 it does is construct the appropriate command that you will need to enter at

--- a/man/run_locally.Rd
+++ b/man/run_locally.Rd
@@ -4,10 +4,19 @@
 \alias{run_locally}
 \title{Deploy a jspsych experiment locally}
 \usage{
-run_locally(path, port = 8000)
+run_locally(
+  path,
+  experiment_folder = "experiment",
+  data_folder = "data",
+  port = 8000
+)
 }
 \arguments{
-\item{path}{Path to the experiment folder}
+\item{path}{Path where the experiment is deployed}
+
+\item{experiment_folder}{Experiment subfolder}
+
+\item{data_folder}{Data subfolder}
 
 \item{port}{The port to use}
 }
@@ -17,11 +26,12 @@ Deploy a jspsych experiment locally
 \details{
 The purpose of the \code{run_locally()} function is to start an
 R server running (using the plumber package) that will
-serve the experiment from the local machine. The \code{path} argument
-specifies the location of the experiment to be run, and should be the same
-as the value of \code{path} that was used when calling
-\code{\link{build_experiment}()}) to build the experiment originally. The
-\code{port} is the numeric value of the port on which the experiment is served.
+serve the experiment from the local machine. The \code{path},
+\code{experiment_folder} and \code{data_folder} arguments specify the location
+specify where the experiment should be deployed, and should be the same
+that was used when calling \code{\link{build_experiment}()}) to build the
+experiment originally. The \code{port} is the numeric value of the port on
+which the experiment is served.
 Once \code{run_locally()} has been called, a browser window should open
 showing the relevant page.
 
@@ -41,7 +51,7 @@ The second reason for using \code{run_locally()} is that it opens up the possibi
 that an experiment could use server-side R code at runtime. At the moment jaysire
 does not have any functionality to do so, but in principle there is nothing
 preventing the R server from playing a more active role when the experiment is
-running, and future versions of the package may develope this functionality
+running, and future versions of the package may develop this functionality
 further.
 }
 \seealso{

--- a/man/run_webserver.Rd
+++ b/man/run_webserver.Rd
@@ -4,10 +4,18 @@
 \alias{run_webserver}
 \title{Deploy a jspsych experiment to a webserver}
 \usage{
-run_webserver(path, ssh, keyfile = NULL, webserver_configured = FALSE)
+run_webserver(
+  path,
+  experiment_folder = "experiment",
+  ssh,
+  keyfile = NULL,
+  webserver_configured = FALSE
+)
 }
 \arguments{
-\item{path}{path to the experiment folder}
+\item{path}{Path where the experiment is deployed}
+
+\item{experiment_folder}{Experiment subfolder}
 
 \item{ssh}{ssh connection string to a webserver}
 


### PR DESCRIPTION
This pull request allows setting `experiment_folder` and `data_folder` other than default: `"experiment"` and `"data"`.

I changed this because (I think) I need to set the experiment in the root path or in the `"html"` subfolder in Pavlovia.

The changes work for me but I only tested running code locally, please revise the other bits in the api to ensure everything is ok. I wouldn't like to break anything.