### PR TITLE
utf-8 charset

### DIFF
--- a/R/build_experiment.R
+++ b/R/build_experiment.R
@@ -283,6 +283,7 @@ build_experiment <- function(timeline, path, experiment_folder = "experiment", d
     '<!DOCTYPE html>',
     '  <html lang="en-us">',
     '  <head>',
+    '    <meta charset="utf-8">',
     paste0('    <link rel="stylesheet" href="resource/style/', stylesheets, '">'),
     paste0('    <script src="resource/script/', scripts, '"></script>'),
     paste0('    <script src="experiment.js"></script>')


### PR DESCRIPTION
Weird symbols appear in Pavlovia as Pavlovia is not setting UTF-8 charset by default (please see https://github.com/jspsych/jsPsych/discussions/765).

This commit adds `<meta charset='utf-8'>` to the header.